### PR TITLE
Added {api_version} to request

### DIFF
--- a/verify/backend/fdm.py
+++ b/verify/backend/fdm.py
@@ -52,7 +52,8 @@ def fdm_login(
     host=FDM.get("host"),
     port=FDM.get("port"),
     username=FDM.get("username"),
-    password=FDM.get("password"),
+    password=FDM.get("password"), 
+    api_version=FDM.get("api_version"),
 ):
     """Login to FDM and return an access token that may be used for API calls.
     """
@@ -70,7 +71,7 @@ def fdm_login(
     }
 
     response = requests.post(
-        f"https://{host}:{port}/api/fdm/v1/fdm/token",
+        f"https://{host}:{port}/api/fdm/v{api_version}/fdm/token",
         headers=headers,
         json=payload,
         verify=False,


### PR DESCRIPTION
Request is always done to v1 version, but v3 is current one and there is a variable "api_version", which can solve this and future issues.