### PR TITLE
Update post_to_amp() code

### DIFF
--- a/intro-amp/amp_custom_detect.py
+++ b/intro-amp/amp_custom_detect.py
@@ -85,7 +85,7 @@ def post_to_amp(
 
     url = f"https://{client_id}:{api_key}@{host}/v1/file_lists/{list_id}/files/{SAMPLE_SHA256}"
 
-    response = requests.post(url, post_this, verify=False)
+    response = requests.post(url, payload, verify=False)
     response.raise_for_status()
 
     rdata = response.json()["data"]


### PR DESCRIPTION
When sending the POST request, we should use the payload from the argument of the post_to_amp() function, not the external variable.